### PR TITLE
Fix a minor spelling error in compiler error message

### DIFF
--- a/lib/surface/compiler.ex
+++ b/lib/surface/compiler.ex
@@ -1115,7 +1115,7 @@ defmodule Surface.Compiler do
     header_message =
       if component_slotable?(template_meta.module) do
         """
-        The slotable component <#{inspect(template_meta.module)}> as the `:slot` option set to \
+        The slotable component <#{inspect(template_meta.module)}> has the `:slot` option set to \
         `#{slot_name}`.
 
         That slot name is not declared in parent component <#{parent_meta.node_alias}>.

--- a/test/surface/integrations/slot_test.exs
+++ b/test/surface/integrations/slot_test.exs
@@ -988,7 +988,7 @@ defmodule Surface.SlotSyncTest do
       end
 
     message = """
-    code:2: The slotable component <Surface.SlotTest.InnerData> as the `:slot` option set to `inner`.
+    code:2: The slotable component <Surface.SlotTest.InnerData> has the `:slot` option set to `inner`.
 
     That slot name is not declared in parent component <StatefulComponent>.
 


### PR DESCRIPTION
A tiny fix to error documentation:
Before:
The slotable component <#{inspect(template_meta.module)}> as the `:slot` option set to 

After:
The slotable component <#{inspect(template_meta.module)}> _has_ the `:slot` option set to 